### PR TITLE
Don't run 'kubeadm token create' as root.

### DIFF
--- a/3-kubeadm_join_nodes.sh
+++ b/3-kubeadm_join_nodes.sh
@@ -5,7 +5,7 @@ for NODE in ${NODES}; do
 multipass exec ${NODE} -- bash -c "sudo mkdir -p /home/ubuntu/.kube/"
 multipass exec ${NODE} -- bash -c "sudo chown ubuntu:ubuntu /home/ubuntu/.kube/"
 multipass transfer kubeconfig.yaml ${NODE}:/home/ubuntu/.kube/config
-multipass exec ${NODE} -- bash -c "sudo kubeadm token create --print-join-command >> kubeadm_join_cmd.sh"
+multipass exec ${NODE} -- bash -c "kubeadm token create --print-join-command >> kubeadm_join_cmd.sh"
 multipass exec ${NODE} -- bash -c "sudo chmod +x kubeadm_join_cmd.sh"
 multipass exec ${NODE} -- bash -c "sudo sh ./kubeadm_join_cmd.sh"
 done


### PR DESCRIPTION
Our config is saved in /home/ubuntu/.kube... NOT /root/.kube...